### PR TITLE
Add visitor statistics for the repository

### DIFF
--- a/.github/workflows/stats.yaml
+++ b/.github/workflows/stats.yaml
@@ -1,0 +1,17 @@
+on:
+  schedule:
+    # Run this once per day, towards the end of the day for keeping the most
+    # recent data point most meaningful (hours are interpreted in UTC).
+    - cron: "0 23 * * *"
+  workflow_dispatch:
+
+jobs:
+  j1:
+    name: repo-stats-for-traffic
+    runs-on: ubuntu-latest
+    steps:
+      - name: run-ghrs
+        uses: jgehrcke/github-repo-stats@RELEASE
+        with:
+          ghtoken: ${{ secrets.REPO_STATS }}
+          databranch: repo_stats


### PR DESCRIPTION
You will also need to set the `REPO_STATS` secret for this to work. Check the action details for what permissions the token needs to have. Or you can just set them all ;)

Signed-off-by: Cezar Craciunoiu <cezar.craciunoiu@gmail.com>